### PR TITLE
Export propagated masks per object

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,10 @@ pip install -e .
 python examples/download_checkpoints.py     # downloads SAM‑2 weights
 jupyter lab notebooks/00_quick_start.ipynb
 ```
+
+After propagating masks in the notebook you can export them as PNG files:
+
+```python
+from cataractsam2 import Masks
+Masks("./masks")  # writes one PNG per frame/object
+```

--- a/cataractsam2/__init__.py
+++ b/cataractsam2/__init__.py
@@ -1,4 +1,4 @@
-from .ui_widget import Object, Reset, Visualize, Propagate
+from .ui_widget import Object, Reset, Visualize, Propagate, video_segments
 from .masks     import Masks
 from .predictor import Predictor
 
@@ -6,4 +6,5 @@ __all__ = [
     "Object", "Reset", "Visualize", "Propagate",
     "Masks",
     "Predictor",
+    "video_segments",
 ]


### PR DESCRIPTION
## Summary
- export the global `video_segments` masks from the widget
- `Masks()` now writes one PNG per frame/object
- re-export `video_segments` through the package
- document mask export usage in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686717bfc2a88329af1b3d6a5377fc0e