### PR TITLE
Fix propagate preview iteration

### DIFF
--- a/cataractsam2/ui_widget.py
+++ b/cataractsam2/ui_widget.py
@@ -199,7 +199,7 @@ def Propagate(vis_frame_stride: int):
         plt.title(f"Frame {idx}")
         plt.imshow(Image.open(os.path.join(video_dir, frame_names[idx])))
         plt.axis("off")
-        for oid, mask in video_segments[idx].items():
+        for oid, mask in video_segments.get(idx, {}).items():
             show_mask(mask, plt.gca(), obj_id=oid)
         plt.show()
 


### PR DESCRIPTION
## Summary
- avoid KeyErrors in preview loop when frames have no objects

## Testing
- `python -m py_compile cataractsam2/ui_widget.py`


------
https://chatgpt.com/codex/tasks/task_e_6867189b42cc8329b6caee970bef27f6