### PR TITLE
Fix widget object reset & point style

### DIFF
--- a/cataractsam2/ui_widget.py
+++ b/cataractsam2/ui_widget.py
@@ -132,16 +132,16 @@ def _visualize(_=None):
 # ─────────────────────── public API ─────────────────────────
 def Object(frame_idx: int, obj_id: int):
     """Start annotating object <obj_id> on frame <frame_idx>."""
-    global ann_frame_idx, ann_obj_id, frame_path, positive_points, negative_points
+    global ann_frame_idx, ann_obj_id, positive_points, negative_points
     clear_output(wait=True)
     ann_frame_idx, ann_obj_id = frame_idx, obj_id
-    frame_path = os.path.join(video_dir, frame_names[frame_idx])
 
     positive_points.clear()
     negative_points.clear()
-    prompts.clear()
     widget.bboxes = []
-    widget.image  = encode_image(frame_path, size=THUMB_SIZE)
+    widget.image = encode_image(
+        os.path.join(video_dir, frame_names[frame_idx]), size=THUMB_SIZE
+    )
     plot_output.clear_output(wait=True)
     _set_mode("positive")
 

--- a/cataractsam2/utils.py
+++ b/cataractsam2/utils.py
@@ -29,10 +29,14 @@ def show_mask(mask: np.ndarray, ax, obj_id=None, random_color=False):
 def show_points(coords: np.ndarray, labels: np.ndarray, ax, marker_size=200):
     pos = coords[labels == 1]
     neg = coords[labels == 0]
-    ax.scatter(pos[:, 0], pos[:, 1], color="lime", marker="*", s=marker_size,
-               edgecolor="white", linewidth=1.2)
-    ax.scatter(neg[:, 0], neg[:, 1], color="red", marker="*", s=marker_size,
-               edgecolor="white", linewidth=1.2)
+    ax.scatter(
+        pos[:, 0], pos[:, 1], color="green", marker="*", s=marker_size,
+        edgecolor="white", linewidth=1.25
+    )
+    ax.scatter(
+        neg[:, 0], neg[:, 1], color="red", marker="*", s=marker_size,
+        edgecolor="white", linewidth=1.25
+    )
 
 
 def show_box(box, ax):


### PR DESCRIPTION
## Summary
- tweak show_points to use green color and 1.25 linewidth
- remove unused global and prompts clearing from Object()

## Testing
- `python -m compileall cataractsam2`

------
https://chatgpt.com/codex/tasks/task_e_6866f0a86d88832987ccfb8ecfa1067d