### PR TITLE
Switch checkpoint download to Hugging Face

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ python examples/download_checkpoints.py
 
 The environment requires Python 3.10+ and the packages listed in
 `requirements.txt`.  The weight download script fetches the public SAM-2
-checkpoints released by Meta.  They are stored in `checkpoints/` and are
+checkpoint from the `DhanvinG/Cataract-SAM2` repository on Hugging Face.
+It is stored in `checkpoints/` and is
 needed before using the library.
 
 ## Quick start
@@ -65,7 +66,7 @@ Masks("./masks")  # one PNG per frame/object
 
 - `cataractsam2/` – library code wrapping SAM-2 and the widget interface.
 - `examples/download_checkpoints.py` – helper script to obtain SAM-2
-  weights from Meta.
+  weights from Hugging Face.
 - `data/` – place your frame sequences here (not included).
 
 ## Acknowledgements

--- a/examples/download_checkpoints.py
+++ b/examples/download_checkpoints.py
@@ -1,11 +1,22 @@
-import pathlib, requests
+"""Download SAM-2 weights from Hugging Face.
 
-URL  = "https://dl.fbaipublicfiles.com/segment_anything_2/072824/sam2_hiera_large.pt"
-dest = pathlib.Path(__file__).resolve().parents[1] / "checkpoints" / "sam2_hiera_large.pt"
-dest.parent.mkdir(parents=True, exist_ok=True)
+This script fetches the pretrained checkpoint from the public
+"DhanvinG/Cataract-SAM2" repository and places it in ``checkpoints/``.
+It mirrors the behaviour of the original download script but uses
+``huggingface_hub`` instead of a direct HTTP request.
+"""
 
-print("⇣", URL)
-with requests.get(URL, stream=True) as r, open(dest, "wb") as f:
-    for chunk in r.iter_content(8192):
-        f.write(chunk)
-print("✔ downloaded →", dest)
+from pathlib import Path
+from huggingface_hub import hf_hub_download
+
+
+dest = Path(__file__).resolve().parents[1] / "checkpoints"
+dest.mkdir(parents=True, exist_ok=True)
+
+print("⇣ huggingface")
+hf_hub_download(
+    repo_id="DhanvinG/Cataract-SAM2",
+    filename="Cataract-SAM2.pth",
+    local_dir=dest,
+)
+print("✔ downloaded →", dest / "Cataract-SAM2.pth")

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ opencv-python
 jupyter-bbox-widget==0.6.0
 # jupyter-bbox-widget @ git+https://github.com/roboflow/bbox-widget.git
 requests
+huggingface-hub
 sam-2 @ git+https://github.com/facebookresearch/segment-anything-2@main


### PR DESCRIPTION
## Summary
- use `huggingface_hub.hf_hub_download` in the checkpoint downloader
- mention Hugging Face weights in README
- require `huggingface-hub` package

## Testing
- `python -m py_compile examples/download_checkpoints.py`
- `python -m py_compile cataractsam2/*.py`


------
https://chatgpt.com/codex/tasks/task_e_686950ffcf3c8329a804f8ff4559f36a