### PR TITLE
Fix Hydra config path and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,19 +33,15 @@ Place your video frames as numbered JPEG files under a directory
 ```python
 from cataractsam2 import Predictor, setup, Object
 
+# the YAML configuration is bundled with the package
 pred = Predictor("checkpoints/Cataract-SAM2.pth")
-# if Hydra can't locate the YAML, pass it explicitly
-# pred = Predictor(
-#     "checkpoints/Cataract-SAM2.pth",
-#     config_file="cataractsam2/cfg/sam2_hiera_l.yaml",
-# )
 setup(pred, "data/frames")
 Object(0, 1)  # start annotating object 1 on frame 0
 ```
 
-`Predictor` passes Hydra the bundled configuration
+`Predictor` automatically loads the bundled configuration
 `cataractsam2/cfg/sam2_hiera_l.yaml`.  If you need to override this file,
-specify `config_file=PATH` when instantiating the class.
+provide `config_file=PATH` when instantiating the class.
 
 Click positive/negative points or draw bounding boxes to guide the model.
 You can visualise intermediate masks with:

--- a/cataractsam2/predictor.py
+++ b/cataractsam2/predictor.py
@@ -1,7 +1,9 @@
 from pathlib import Path
 from sam2.build_sam import build_sam2_video_predictor
 
-CFG   = Path(__file__).with_suffix("").parent / "cfg" / "sam2_hiera_l.yaml"
+# Default configuration packaged with the library.  Using the ``pkg://``
+# scheme makes Hydra load the YAML from this installed module.
+CFG   = "pkg://cataractsam2/cfg/sam2_hiera_l.yaml"
 
 class Predictor:
     """
@@ -30,8 +32,9 @@ class Predictor:
         device: str = "cuda",
     ):
         """Wrap ``build_sam2_video_predictor`` with sane defaults."""
+        config_file = str(config_file)
         self.pred = build_sam2_video_predictor(
-            config_file=str(Path(config_file)),
+            config_file=config_file,
             ckpt=str(weights),
             device=device,
         )

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ setup(
     version="0.1.0",
     packages=find_packages(),
     include_package_data=True,      # ships YAML inside cfg/
+    package_data={"cataractsam2": ["cfg/*.yaml"]},
     python_requires=">=3.10",
     install_requires=[l.strip() for l in open("requirements.txt") if l.strip()],
     author="Dhanvin Ganeshkumar",


### PR DESCRIPTION
## Summary
- package YAML with the wheel
- default Predictor to use `pkg://` path so Hydra can locate the config
- simplify quick-start instructions in README

## Testing
- `pip install -e .` *(fails: build dependencies could not be installed)*
- `python setup.py egg_info` *(fails: ModuleNotFoundError: No module named 'setuptools')*
- `git clone https://github.com/DhanvinG/Cataract-SAM2.git testclone` *(fails: tunnel connection 403)*

------
https://chatgpt.com/codex/tasks/task_e_6869b2f3da1883298b3dc9834691ab3d